### PR TITLE
Multiple modernizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,29 @@
-dist: trusty
+dist: xenial
 sudo: false
 
 matrix:
-    fast_finish: true
+  fast_finish: true
 
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  # - "3.7"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.6-dev"
   - "3.7-dev"
+  - "3.8-dev"
+  - "3.9-dev"
 
 before_install:
   - pip freeze
-  - travis_retry pip install --upgrade pip pep8 coverage coveralls
+  - travis_retry pip install --upgrade pip
+  - travis_retry pip install --upgrade pycodestyle
+  - travis_retry pip install --upgrade pylint
   - pip freeze
 
 
-
 script:
-  - pep8 -v check_x509_expire
+  - pycodestyle --max-line-length=100 --statistics check_x509_expire
+  - pylint check_x509_expire
   - ./check_x509_expire -s example.com -p 443 -w 28 -c 21

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ A basic Nagios/Icinga plugin to check the expiry of an x509 certificate.
 
 STARTTLS can be used by passing the appropriate protocol. Any protocol supported by your version of OpenSSL should work.
 
-## Usage
+### Requirements
+
+* Python 3.6+
+
+### Plugin Installation
 
 * Download check_x509_expire to your PluginContribDir
 * Add/Import the CheckCommand configuration
 
 ## Contributing
+
 1. Fork the repo
-  * Create a new feature branch
+
+* Create a new feature branch
+
 2. Make your edits, commit and push
 3. Create a [Pull Request](https://github.com/leeclemens/check_x509_expire/pulls)
 

--- a/check_x509_expire
+++ b/check_x509_expire
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Generic check for monitoring a certificate's expiration date
 
@@ -27,6 +27,7 @@ SOFTWARE.
 
 from __future__ import print_function
 
+import argparse
 import datetime
 import re
 import subprocess
@@ -46,140 +47,82 @@ PREFIXES = {
 }
 
 
-def usage():
-    print('Usage: %s -s server -p port -w days -c days'
-          ' [-t <protocol>]' % sys.argv[0])
-    print('\t-s server      server name')
-    print('\t-p port        port')
-    print('\t-w days        warning threshold')
-    print('\t-c days        critical threshold')
-    print('\t-t proto       starttls protocol')
-    sys.exit(STATUS_UNKNOWN)
+def run(args):
+    """Main run function to execute this check
+    """
+    # Enhance: Use shlex and python pipes
+    openssl_cmd = (
+        'echo'
+        ' | openssl s_client -crlf'
+        ' {}'
+        ' -servername {}'
+        ' -connect {}:{} 2>/dev/null'
+        ' | openssl x509 -noout -dates'.format(
+            '-starttls {}'.format(args.starttls) if args.starttls else '',
+            args.server,
+            args.server,
+            args.port))
+    with subprocess.Popen(openssl_cmd, shell=True,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+        stdout, stderr = proc.communicate()
+        if proc.returncode == 0:
+            regex = re.compile(r"^notBefore=(?P<before>(.*))\n"
+                               r"notAfter=(?P<after>(.*))\n", re.MULTILINE)
+            match = regex.match(stdout
+                                if isinstance(stdout, str)
+                                else stdout.decode('utf-8'))
+            if match:
+                cert_date_format = "%b %d %H:%M:%S %Y %Z"
+                before = datetime.datetime.strptime(match.group('before'),
+                                                    cert_date_format)
+                after = datetime.datetime.strptime(match.group('after'),
+                                                   cert_date_format)
+            else:
+                print(stdout)
+                print('Unexpected number of certificates')
+                sys.exit(STATUS_CRITICAL)
+            assert before is not None
+            assert after is not None
 
-
-def parse_args():
-    args_dict = {
-        'server': None,
-        'port': None,
-        'warning': None,
-        'critical': None,
-        'starttls': None,
-    }
-    i = 1
-    while i < len(sys.argv):
-        arg = sys.argv[i]
-        if arg == '-s':
-            if i + 1 < len(sys.argv):
-                i += 1
-                args_dict['server'] = sys.argv[i]
-            else:
-                print('-s requires a value, server')
-                usage()
-        elif arg == '-p':
-            if i + 1 < len(sys.argv):
-                i += 1
-                try:
-                    args_dict['port'] = int(sys.argv[i])
-                except ValueError:
-                    print('-p port must be an integer')
-                    usage()
-            else:
-                print('-p requires a value, port')
-                usage()
-        elif arg == '-w':
-            if i + 1 < len(sys.argv):
-                i += 1
-                try:
-                    args_dict['warning'] = int(sys.argv[i])
-                except ValueError:
-                    print('-w days must be an integer')
-                    usage()
-            else:
-                print('-w requires a value, days')
-                usage()
-        elif arg == '-c':
-            if i + 1 < len(sys.argv):
-                i += 1
-                try:
-                    args_dict['critical'] = int(sys.argv[i])
-                except ValueError:
-                    print('-c days must be an integer')
-                    usage()
-            else:
-                print('-c requires a value, days')
-                usage()
-        elif arg == '-t':
-            if i + 1 < len(sys.argv):
-                i += 1
-                args_dict['starttls'] = sys.argv[i]
-            else:
-                print('-s requires a value, starttls protocol')
-                usage()
-        i += 1
-    return args_dict
-
-
-def run(server, port, warning, critical, starttls):
-    # TODO: Use pipe-aware Popen calls
-    openssl_cmd = 'echo' \
-                  ' | openssl s_client -crlf %s-servername %s' \
-                  ' -connect %s:%s 2>/dev/null' \
-                  ' | openssl x509 -noout -dates' \
-                  % ('-starttls %s ' % starttls if starttls else '',
-                     server, server, port)
-    proc = subprocess.Popen(openssl_cmd, shell=True,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = proc.communicate()
-    if proc.returncode == 0:
-        regex = re.compile(r"^notBefore=(?P<before>(.*))\n"
-                           r"notAfter=(?P<after>(.*))\n", re.MULTILINE)
-        # TODO: Better py2-3 compatibility (no install, 2to3)
-        match = regex.match(stdout
-                            if isinstance(stdout, str)
-                            else stdout.decode('utf-8'))
-        if match:
-            cert_date_format = "%b %d %H:%M:%S %Y %Z"
-            before = datetime.datetime.strptime(match.group('before'),
-                                                cert_date_format)
-            after = datetime.datetime.strptime(match.group('after'),
-                                               cert_date_format)
+            cur_time = datetime.datetime.utcnow()
+            process_cert_time(args, before, after, cur_time)
         else:
-            print(stdout)
-            print('Unexpected number of certificates')
+            print('Failed to execute %s %s %s' %
+                  (openssl_cmd, stdout, stderr))
             sys.exit(STATUS_CRITICAL)
-        assert before is not None
-        assert after is not None
 
-        cur_time = datetime.datetime.utcnow()
-        if before <= cur_time:
-            if after >= cur_time:
-                if after - cur_time <= datetime.timedelta(days=warning):
-                    if after - cur_time <= datetime.timedelta(days=critical):
-                        exit_with_perf_data(after, cur_time, STATUS_CRITICAL)
-                    else:
-                        exit_with_perf_data(after, cur_time, STATUS_WARNING)
+
+def process_cert_time(args, before, after, cur_time):
+    """Process the certificate times and determine result
+    Call exit_with_perf_data
+    """
+    if before <= cur_time:
+        if after >= cur_time:
+            if after - cur_time <= datetime.timedelta(days=args.warning):
+                if after - cur_time <= datetime.timedelta(days=args.critical):
+                    exit_with_perf_data(after, cur_time, STATUS_CRITICAL)
                 else:
-                    exit_with_perf_data(after, cur_time, STATUS_OK)
+                    exit_with_perf_data(after, cur_time, STATUS_WARNING)
             else:
-                print('Certificate in no longer valid')
-                exit_with_perf_data(after, cur_time, STATUS_CRITICAL)
+                exit_with_perf_data(after, cur_time, STATUS_OK)
         else:
-            print('Certificate is not yet valid')
-            exit_with_perf_data(after, cur_time, STATUS_CRITICAL, before)
+            print('Certificate in no longer valid')
+            exit_with_perf_data(after, cur_time, STATUS_CRITICAL)
     else:
-        print('Failed to execute %s %s %s' %
-              (openssl_cmd, stdout, stderr))
-        sys.exit(STATUS_CRITICAL)
+        print('Certificate is not yet valid')
+        exit_with_perf_data(after, cur_time, STATUS_CRITICAL, before=before)
 
 
 def exit_with_perf_data(after, cur_time, exit_code, before=None):
+    """Print result with perf data and exit
+    """
     time_remaining = after - cur_time
     if hasattr(time_remaining, 'total_seconds'):
         time_remaining_sec = time_remaining.total_seconds()
     else:
-        time_remaining_sec = (time_remaining.microseconds + (
-            time_remaining.seconds + time_remaining.days * 24 * 3600) *
-                              10 ** 6) / 10 ** 6
+        time_remaining_sec = (time_remaining.microseconds
+                              + (time_remaining.seconds + time_remaining.days * 24 * 3600)
+                              * 10 ** 6) / 10 ** 6
     perf_data_days = time_remaining_sec / 60 / 60 / 24
     print('%s - Expires: %s%s | days_remaining=%s' % (
         PREFIXES[exit_code],
@@ -190,31 +133,45 @@ def exit_with_perf_data(after, cur_time, exit_code, before=None):
     sys.exit(exit_code)
 
 
+def parse_args():
+    """Parse command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        'This plugin checks the Elasticsearch snapshots for either all'
+        ' or a specific repository. It will test the age'
+        ' of any successful snapshot, using the newest in each repository.')
+    parser.add_argument('-s', '--server', type=str,
+                        required=True,
+                        dest='server',
+                        help='server to test')
+    parser.add_argument('-p', '--port', type=int,
+                        required=True,
+                        dest='port',
+                        default=443,
+                        help='port to connect to')
+    parser.add_argument('-w', '--warning', type=int,
+                        required=True,
+                        dest='warning',
+                        help='warning days as an integer, must be > critical days')
+    parser.add_argument('-c', '--critical', type=int,
+                        required=True,
+                        dest='critical',
+                        help='critical days as an integer')
+    parser.add_argument('-t', '--starttls', type=str,
+                        dest='starttls',
+                        required=False,
+                        default='',
+                        help='STARTTLS Protocol (e.g. smtp)')
+    args = parser.parse_args()
+    if args.warning < args.critical:
+        print('Warning must be greater than critical')
+        sys.exit(STATUS_CRITICAL)
+    return args
+
+
 if __name__ == '__main__':
     try:
-        if len(sys.argv) == 1 or '-h' in sys.argv or '--help' in sys.argv:
-            usage()
-        else:
-            ARGS = parse_args()
-            if ARGS['server'] is None:
-                print('Server must be provided')
-                usage()
-            if ARGS['port'] is None:
-                print('Port must be provided')
-                usage()
-            if ARGS['warning'] is None:
-                print('Warning days must be provided')
-                usage()
-            if ARGS['critical'] is None:
-                print('Critical days must be provided')
-                usage()
-            if ARGS['warning'] < ARGS['critical']:
-                print('Warning days must be greater than or equal'
-                      ' to critical days')
-                usage()
-            run(ARGS['server'], ARGS['port'],
-                ARGS['warning'], ARGS['critical'],
-                ARGS['starttls'])
+        run(parse_args())
     # pylint: disable=broad-except
     except Exception as ex:
         print('%s: Unhandled exception %s' % (sys.argv[0], type(ex)))

--- a/check_x509_expire_config
+++ b/check_x509_expire_config
@@ -5,11 +5,11 @@ object CheckCommand "x509_expire" {
 	command = [ PluginContribDir + "/check_x509_expire" ]
 
 	arguments = {
-		"-s" = "$x509_expire_server$"
-		"-p" = "$x509_expire_port$"
-		"-w" = "$x509_expire_warning$"
-		"-c" = "$x509_expire_critical$"
-		"-t" = "$x509_expire_starttls$"
+		"--server" = "$x509_expire_server$"
+		"--port" = "$x509_expire_port$"
+		"--warning" = "$x509_expire_warning$"
+		"--critical" = "$x509_expire_critical$"
+		"--starttls" = "$x509_expire_starttls$"
 	}
 
 	vars.x509_expire_warning = 14

--- a/pylintrc
+++ b/pylintrc
@@ -1,288 +1,231 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
 
-# Python code to execute, usually for sys.path manipulation such as
-# pygtk.require().
-#init-hook=
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=CVS
 
-# Pickle collected data for later comparisons.
-persistent=yes
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
 
-# List of plugins (as comma separated values of python modules names) to load,
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
 # usually to register additional checkers.
 load-plugins=
 
-# Use multiple processes to speed up Pylint.
-jobs=1
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code
-extension-pkg-whitelist=
-
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
-optimize-ast=no
-
 
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
 confidence=
-
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time. See also the "--disable" option for examples.
-#enable=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
+# file where it should appear only once). You can also use "--disable=all" to
 # disable everything first and then reenable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
 
 
 [REPORTS]
 
-# Set the output format. Available formats are text, parseable, colorized, msvs
-# (visual studio) and html. You can also give a reporter class, eg
-# mypackage.mymodule.MyReporterClass.
-output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
-# Tells whether to display a full report or only the messages
-reports=yes
-
-# Python expression which should return a note less than 10 (10 is the highest
-# note). You have access to the variables errors warning, statement which
-# respectively contain the number of errors / warnings messages and the total
-# number of statements analyzed. This is used by the global evaluation report
-# (RP0004).
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details
+# used to format the message information. See doc for all details.
 #msg-template=
 
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
 
-[TYPECHECK]
+# Tells whether to display a full report or only the messages.
+reports=no
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# mixin class is detected if its name ends with "mixin" (case insensitive).
-ignore-mixin-members=yes
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis. It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
-
-# List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamically set). This supports can work
-# with qualified names.
-ignored-classes=
-
-# List of members which are set dynamically and missed by pylint inference
-# system, and so shouldn't trigger E1101 when accessed. Python regular
-# expressions are accepted.
-generated-members=
+# Activate the evaluation score.
+score=yes
 
 
-[FORMAT]
-
-# Maximum number of characters on a single line.
-max-line-length=100
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
-
-# Maximum number of lines in a module
-max-module-lines=1000
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Number of spaces of indent required inside a hanging  or continued line.
-indent-after-paren=4
-
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-
-[VARIABLES]
-
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
-
-# A regular expression matching the name of dummy variables (i.e. expectedly
-# not used).
-dummy-variables-rgx=_$|dummy
-
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
-
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,_cb
-
-
-[SPELLING]
-
-# Spelling dictionary name. Available dictionaries: none. To make it working
-# install python-enchant package.
-spelling-dict=
-
-# List of comma separated words that should not be checked.
-spelling-ignore-words=
-
-# A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file=
-
-# Tells whether to store unknown words to indicated private dictionary in
-# --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words=no
-
-
-[BASIC]
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,input
-
-# Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
-
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
-
-# Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Regular expression matching correct attribute names
-attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct argument names
-argument-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Regular expression matching correct inline iteration names
-inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
-# Regular expression matching correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
-# Regular expression matching correct module names
-module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
-# Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
-
-# Regular expression which should only match function or class names that do
-# not require a docstring.
-no-docstring-rgx=^_
-
-# Minimum line length for functions/classes that require docstrings, shorter
-# ones are exempt.
-docstring-min-length=-1
-
-
-[ELIF]
+[REFACTORING]
 
 # Maximum number of nested blocks for function / method body
 max-nested-blocks=5
 
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
 
-[LOGGING]
 
-# Logging modules to check that the string format arguments are in logging
-# function parameter format
-logging-modules=logging
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
 
 
 [SIMILARITIES]
-
-# Minimum lines number of a similarity.
-min-similarity-lines=4
 
 # Ignore comments when computing similarities.
 ignore-comments=yes
@@ -293,86 +236,358 @@ ignore-docstrings=yes
 # Ignore imports when computing similarities.
 ignore-imports=no
 
+# Minimum lines number of a similarity.
+min-similarity-lines=4
 
-[MISCELLANEOUS]
 
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: en_AG (hunspell), en_AU
+# (hunspell), en_BS (hunspell), en_BW (hunspell), en_BZ (hunspell), en_CA
+# (hunspell), en_DK (hunspell), en_GB (hunspell), en_GH (hunspell), en_HK
+# (hunspell), en_IE (hunspell), en_IN (hunspell), en_JM (hunspell), en_MW
+# (hunspell), en_NA (hunspell), en_NG (hunspell), en_NZ (hunspell), en_PH
+# (hunspell), en_SG (hunspell), en_TT (hunspell), en_US (hunspell), en_ZA
+# (hunspell), en_ZM (hunspell), en_ZW (hunspell).
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
 
 
 [IMPORTS]
 
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=regsub,TERMIOS,Bastion,rexec
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
 
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
 
 # Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled)
+# not be disabled).
 ext-import-graph=
 
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
 # Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled)
+# not be disabled).
 int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
 
 
 [CLASSES]
 
 # List of method names used to declare (i.e. assign) instance attributes.
-defining-attr-methods=__init__,__new__,setUp
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=mcs
-
-# List of member names, which should be excluded from the protected access
-# warning.
-exclude-protected=_asdict,_fields,_replace,_source,_make
-
-
-[DESIGN]
-
-# Maximum number of arguments for function / method
-max-args=5
-
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*
-
-# Maximum number of locals for function / method body
-max-locals=15
-
-# Maximum number of return / yield for function / method body
-max-returns=6
-
-# Maximum number of branch for function / method body
-max-branches=12
-
-# Maximum number of statements in function / method body
-max-statements=50
-
-# Maximum number of parents for a class (see R0901).
-max-parents=7
-
-# Maximum number of attributes for a class (see R0902).
-max-attributes=7
-
-# Minimum number of public methods for a class (see R0903).
-min-public-methods=2
-
-# Maximum number of public methods for a class (see R0904).
-max-public-methods=20
-
-# Maximum number of boolean expressions in a if statement
-max-bool-expr=5
+valid-metaclass-classmethod-first-arg=cls
 
 
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
-overgeneral-exceptions=Exception
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception


### PR DESCRIPTION
Require python 3.6+
Use xenial
Add pylint
Install/upgrade pip, pycodestyle, pylint. Replace pep8 with pycodestyle
Use argparse, long arguments
Add docstrings, etc
Set default pylintrc